### PR TITLE
Update Example plist for minimum os, and minimum client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # munki
 Suggested Munki plists for distributing your Watchman Monitoring Monitoring Client.
+
+Set your Watchman Monitoring subdomain in the plist before adding to your Munki repo.
+
+If your subdomain is `pretendco.monitoringclient.com`, you would set `SUBDOMAIN="pretendco"` in two locations, along with setting the `GROUP_NAME`.

--- a/monitoringclient-install.plist
+++ b/monitoringclient-install.plist
@@ -22,9 +22,10 @@
 	<key>postinstall_script</key>
 	<string><![CDATA[#!/bin/bash
 GROUP_NAME="ENTER_GROUP_NAME"
+SUBDOMAIN="ENTER_YOUR_SUBDOMAIN"
 	
 /usr/bin/defaults write /Library/MonitoringClient/ClientSettings ClientGroup -string "$GROUP_NAME"
-/usr/bin/curl -L1 https://YOURSUBDOMAIN.monitoringclient.com/downloads/MonitoringClient.pkg -o /tmp/MonitoringClient.pkg
+/usr/bin/curl -L1 https://$SUBDOMAIN.monitoringclient.com/downloads/MonitoringClient.pkg -o /tmp/MonitoringClient.pkg
 /usr/sbin/installer -target / -pkg /tmp/MonitoringClient.pkg
 /bin/rm /tmp/MonitoringClient.pkg
 exit 0
@@ -32,11 +33,14 @@ exit 0
 	<key>installcheck_script</key>
 	<string><![CDATA[#!/bin/zsh
 autoload is-at-least
+
+SUBDOMAIN="ENTER_YOUR_SUBDOMAIN"
+
 wmsubdomain="$(defaults read /Library/MonitoringClient/ClientSettings Subdomain)"
 wmversion="$(defaults read /Library/MonitoringClient/ClientSettings Client_Version)"
 wmversionmimimum="7.0"
 if [ -e /Library/MonitoringClient/RunClient ] && 
-   [[ $wmsubdomain == "YOURSUBDOMAIN" ]] && 
+   [[ $wmsubdomain == "$SUBDOMAIN" ]] && 
    is-at-least $wmversionmimimum $wmversion 
 then
     exit 1

--- a/monitoringclient-install.plist
+++ b/monitoringclient-install.plist
@@ -14,7 +14,7 @@
 	<key>display_name</key>
 	<string>Monitoring Client</string>
 	<key>minimum_os_version</key>
-	<string>10.7.0</string>
+	<string>10.11.0</string>
 	<key>installer_type</key>
 	<string>nopkg</string>
 	<key>name</key>

--- a/monitoringclient-install.plist
+++ b/monitoringclient-install.plist
@@ -30,9 +30,15 @@ GROUP_NAME="ENTER_GROUP_NAME"
 exit 0
 	]]></string>
 	<key>installcheck_script</key>
-	<string><![CDATA[#!/bin/bash
+	<string><![CDATA[#!/bin/zsh
+autoload is-at-least
 wmsubdomain="$(defaults read /Library/MonitoringClient/ClientSettings Subdomain)"
-if [ -e /Library/MonitoringClient/RunClient ] && [[ $wmsubdomain == 'YOURSUBDOMAIN' ]]; then
+wmversion="$(defaults read /Library/MonitoringClient/ClientSettings Client_Version)"
+wmversionmimimum="7.0"
+if [ -e /Library/MonitoringClient/RunClient ] && 
+   [[ $wmsubdomain == "YOURSUBDOMAIN" ]] && 
+   is-at-least $wmversionmimimum $wmversion 
+then
     exit 1
 else
     exit 0


### PR DESCRIPTION
Updates the munki payload-free plist to check for the current supported macOS version. Revises install check script to also check for Monitoring Client version to potentially upgrade orphaned clients with macOS 12.3.